### PR TITLE
feat: add and delete edges between nodes, note 🐛

### DIFF
--- a/src/components/Editor/AddEdgeDialog.tsx
+++ b/src/components/Editor/AddEdgeDialog.tsx
@@ -1,0 +1,104 @@
+import React, { useState, useEffect } from "react"
+import { node, edge } from "cope-client-utils"
+import styled from "styled-components"
+import {
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    Button,
+    TextField,
+} from "@material-ui/core"
+import { EDGE_TYPES } from "./utils"
+import { SelectInput } from "../AssetWidgets"
+
+const Wrapper = styled.div`
+    margin: 24px 8px;
+`
+
+function AddEdgeDialog({
+    open,
+    setOpen,
+    nodeId,
+}: {
+    open: boolean
+    setOpen: any
+    nodeId?: string
+}) {
+    const [nodesList, setNodesList] = useState<any>({})
+    const [edgeType, setEdgeType] = useState(EDGE_TYPES.AUTHORED) // random default
+    const [toNodeId, setToNodeId] = useState("")
+
+    useEffect(() => {
+        const fetchNodes = async () => {
+            node
+                //@ts-ignore
+                .list({})
+                .then((result: any) => {
+                    const nodes = {}
+                    result.forEach((node: any) => {
+                        nodes[node.id] = node.id
+                    })
+                    setNodesList(nodes)
+                })
+                .catch((error: any) => console.error(error))
+        }
+        fetchNodes()
+    }, [])
+
+    const handleClose = () => {
+        setOpen(false)
+    }
+
+    const createEdge = () => {
+        const data = {
+            type: edgeType,
+            from_node_id: nodeId,
+            to_node_id: toNodeId,
+        }
+        edge.create(data).catch((err: any) => console.error(err))
+        handleClose()
+    }
+
+    return (
+        <Dialog
+            open={open}
+            onClose={handleClose}
+            scroll={"paper"}
+            aria-labelledby="scroll-dialog-title"
+            aria-describedby="scroll-dialog-description"
+        >
+            <DialogTitle id="scroll-dialog-title">Add Edge</DialogTitle>
+            <DialogContent dividers={true}>
+                <Wrapper>
+                    <SelectInput
+                        itemsAndValues={EDGE_TYPES}
+                        inputLabel={"Edge Type"}
+                        selectState={edgeType}
+                        setSelectState={setEdgeType}
+                    />
+                </Wrapper>
+                {nodesList && (
+                    <Wrapper>
+                        <SelectInput
+                            itemsAndValues={nodesList}
+                            inputLabel={"To Node ID"}
+                            selectState={toNodeId}
+                            setSelectState={setToNodeId}
+                        />
+                    </Wrapper>
+                )}
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleClose} color="primary">
+                    Cancel
+                </Button>
+                <Button onClick={createEdge} color="primary">
+                    Add Edge
+                </Button>
+            </DialogActions>
+        </Dialog>
+    )
+}
+
+export default AddEdgeDialog

--- a/src/components/Editor/EdgesList.tsx
+++ b/src/components/Editor/EdgesList.tsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from "react"
+import styled from "styled-components"
+import { node, edge } from "cope-client-utils"
+import { Card, Button } from "@material-ui/core"
+import { Link } from ".."
+
+const EdgesListCard = styled(Card)`
+    margin: 8px 8px;
+`
+
+const EdgesListCardHeading = styled(Card)`
+    padding: 8px 8px;
+    font-size: 1.2em;
+    font-weight: 400;
+`
+
+const EdgesListCardContent = styled.div`
+    padding: 8px;
+`
+
+const EdgesListCardText = styled(Link)`
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 400;
+`
+
+const EdgesListCardType = styled.div`
+    display: inline;
+    float: right;
+    color: gray;
+`
+
+function EdgesList({ edges, nodeId }: { edges: Array<any>; nodeId: string }) {
+    const [linkedNodesList, setLinkedNodesList] = useState<any>([])
+
+    useEffect(() => {
+        edges.forEach(e => {
+            edge.read({ id: e.edge_id }).then(res => {
+                setLinkedNodesList([...linkedNodesList, res])
+            })
+        })
+    }, [])
+
+    const deleteEdge = (edgeId: string) => {
+        edge.delete({ id: edgeId }).catch((err: any) => console.error(err))
+    }
+
+    return (
+        <div>
+            <EdgesListCardHeading>Edges</EdgesListCardHeading>
+            {linkedNodesList.map((edge, i) => {
+                const toNode = edge.nodes.items.filter(n => n.id !== nodeId)[0]
+                return (
+                    <div key={i}>
+                        <EdgesListCard>
+                            <EdgesListCardContent>
+                                <EdgesListCardText
+                                    to={`admin/collections/edit?nodeId=${toNode.node_id}`}
+                                >
+                                    {toNode.node_id}
+                                </EdgesListCardText>
+                                <EdgesListCardType>{edge.type}</EdgesListCardType>
+                                <Button onClick={() => deleteEdge(edge.id)}>Delete Edge</Button>
+                            </EdgesListCardContent>
+                        </EdgesListCard>
+                    </div>
+                )
+            })}
+        </div>
+    )
+}
+
+export default EdgesList

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -9,6 +9,8 @@ import DeleteNodeDialog from "./DeleteNodeDialog"
 import DeleteAssetDialog from "./DeleteAssetDialog"
 import EditorSnackbar from "./EditorSnackbar"
 import RenderContentPreview from "../ContentPreview/RenderContentPreview"
+import EdgesList from "./EdgesList"
+import AddEdgeDialog from "./AddEdgeDialog"
 import { RenderAssetWidget } from "../AssetWidgets"
 import { TEMPLATES } from "../Collections/templates"
 
@@ -33,6 +35,7 @@ function Editor({ nodeId }: { nodeId?: string }) {
     const [userData, setUserData] = useState<any>()
     const [nodeData, setNodeData] = useState<any>()
     const [addAssetDialogOpen, setAddAssetDialogOpen] = useState(false)
+    const [addEdgeDialogOpen, setAddEdgeDialogOpen] = useState(false)
     const [deleteAssetDialogOpen, setDeleteAssetDialogOpen] = useState("")
     const [deleteNodeDialogOpen, setDeleteNodeDialogOpen] = useState(false)
     const [snackbarState, setSnackbarState] = useState({ open: false, message: "" })
@@ -54,7 +57,7 @@ function Editor({ nodeId }: { nodeId?: string }) {
                 node.read({ id: nodeId }).then((res: any) => {
                     // reverse items here such that oldest assets
                     // are displayed first
-                    let sortedItems = res.assets.items
+                    let sortedItems
                     if (res.type in TEMPLATES) {
                         sortedItems = res.assets.items.sort((a, b) => a.index - b.index)
                     }
@@ -158,9 +161,6 @@ function Editor({ nodeId }: { nodeId?: string }) {
                                 </Wrapper>
                             ))}
                         <Wrapper>
-                            <StyledButton variant="contained">Add Parent</StyledButton>
-                            <StyledButton variant="contained">Add Sibling</StyledButton>
-                            <StyledButton variant="contained">Add Child</StyledButton>
                             {nodeId && (
                                 <StyledButton
                                     variant="contained"
@@ -169,6 +169,17 @@ function Editor({ nodeId }: { nodeId?: string }) {
                                     Add Asset
                                 </StyledButton>
                             )}
+                        </Wrapper>
+                        <Wrapper>
+                            {nodeData && (
+                                <EdgesList edges={nodeData.edges.items} nodeId={nodeData.id} />
+                            )}
+                            <StyledButton
+                                variant="contained"
+                                onClick={() => setAddEdgeDialogOpen(true)}
+                            >
+                                Add Edge
+                            </StyledButton>
                         </Wrapper>
                         <Wrapper>
                             {nodeId && (
@@ -185,6 +196,11 @@ function Editor({ nodeId }: { nodeId?: string }) {
                                 </StyledButton>
                             )}
                         </Wrapper>
+                        <AddEdgeDialog
+                            open={addEdgeDialogOpen}
+                            setOpen={setAddEdgeDialogOpen}
+                            nodeId={nodeData ? nodeData.id : ""}
+                        />
                         <AddAssetDialog
                             open={addAssetDialogOpen}
                             setOpen={setAddAssetDialogOpen}

--- a/src/components/Editor/utils.js
+++ b/src/components/Editor/utils.js
@@ -1,4 +1,4 @@
-import { NodeStatus, NodeType, AssetType } from "cope-client-utils/lib/graphql/API"
+import { NodeStatus, NodeType, AssetType, EdgeType } from "cope-client-utils/lib/graphql/API"
 
 export const NODE_STATUSES = {
     DRAFT: NodeStatus.DRAFT,
@@ -45,4 +45,12 @@ export const ASSET_TYPES = {
     F_KML: AssetType.F_KML,
     F_SHP: AssetType.F_SHP,
     F_CSV: AssetType.F_CSV,
+}
+
+export const EDGE_TYPES = {
+    AUTHORED: EdgeType.AUTHORED,
+    HAS_NEXT: EdgeType.HAS_NEXT,
+    HAS_PREVIOUS: EdgeType.HAS_PREVIOUS,
+    HAS_PART: EdgeType.HAS_PART,
+    HAS_CHILD: EdgeType.HAS_CHILD,
 }


### PR DESCRIPTION
Can now add edges between nodes. Behaviour works
as expected and no known bugs.

Deleting edges also works fine. Appears to be consistent and
should probably create a dialog to confirm when a user
wants to delete an edge.

Rendering edges is highly buggy!!

Due to having to query each specific edge in its own promise
(so we can then get the other node that the edge is linked to)
we get some odd behaviour with rendering.

Specifically, not all edges will render upon a page load, it
will usually only render the first promise to complete!! despite!!
all the promises being finished and then local state being updated
with said promises.

Not quite sure what is going on despite console logging and confirming
that all edges are in fact returned from their promises and stored
in local component state.